### PR TITLE
Fix build with gcc14

### DIFF
--- a/FBFDownloader.c
+++ b/FBFDownloader.c
@@ -8,6 +8,7 @@
 #include "BinFileWtp.h"
 #include "kstring.h"
 #include "fbfdownload.h"
+#include <ctype.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/WTPCOMMCLASS.c
+++ b/WTPCOMMCLASS.c
@@ -117,8 +117,8 @@ void HandleTraceLog(struct CWtpComm *me,const TCHAR* format,...)
 		va_start (pArgs, format);
 		vsprintf (szBuffer, format, pArgs);
 		va_end (pArgs);
-		printf(szBuffer);
-		fprintf(me->m_hLog, szBuffer);
+		printf("%s", szBuffer);
+		fprintf(me->m_hLog, "%s", szBuffer);
 	}
 }
 BOOL SendPreamble (struct CWtpComm *me,BOOL bIsCustPreamble)

--- a/WtptpDownloader.c
+++ b/WtptpDownloader.c
@@ -878,7 +878,7 @@ BOOL WtptpDownLoad_GetDeviceBootType(struct CWtptpDownLoad *me,PDEVICE pDev)
 				else
 					tsnprintf(szMessage,MAX_FILE_LENGTH,_T("InitialBL have issue\n"));
 
-				tfprintf (pDev->hLog,szMessage);				
+				tfprintf (pDev->hLog,"%s",szMessage);				
 				return FALSE;
 			}
 		}
@@ -898,7 +898,7 @@ BOOL WtptpDownLoad_GetDeviceBootType(struct CWtptpDownLoad *me,PDEVICE pDev)
 				{
 					tsnprintf(szMessage,MAX_FILE_LENGTH,_T("DDRType is not found , OBM read vendor DDR Pid 0x%x, can't find it in blf configure \n"),uiDdrVendorId<<8|uiDdrUnitSize);
 				}
-				tfprintf (pDev->hLog,szMessage);			
+				tfprintf (pDev->hLog,"%s",szMessage);			
 				return FALSE;
 			}
 		}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+flash-simcom-a76xx (1.1.2) stable; urgency=medium
+
+  * Fix build with gcc14
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 27 Mar 2025 16:30:00 +0400
+
 flash-simcom-a76xx (1.1.1) stable; urgency=medium
 
   * Add arm64 build, no functional changes

--- a/debian/control
+++ b/debian/control
@@ -9,4 +9,4 @@ Package: flash-simcom-a76xx
 Architecture: any
 Depends: wb-utils (>= 4.7.1), ${shlibs:Depends}, ${misc:Depends}
 Description: Simcom modem flash utility
-  Used to update Simcom modem firmware
+ Used to update Simcom modem firmware


### PR DESCRIPTION
```
WtptpDownloader.c:901:54: error: format not a string literal and no format arguments []
  901 |                                 tfprintf (pDev->hLog,szMessage);
      |                                                      ^~~~~~~~~
...
       > FBFDownloader.c:883:45: error: implicit declaration of function 'tolower' []
       >   883 |                                         if (tolower(getchar()) == (int)'q')
       >       |                                             ^~~~~~~
       > FBFDownloader.c:18:1: note: include '<ctype.h>' or provide a declaration of 'tolower'
       >    17 | #include <syslog.h>
       >   +++ |+#include <ctype.h>
       >    18 | #include <sys/stat.h>
```